### PR TITLE
Cleanup: Remove serviceName from controller manifest

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: csi-driver
 spec:
-  serviceName: azure-disk-csi-driver-controller
   replicas: 1
   selector:
     matchLabels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -77,7 +77,6 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: csi-driver
 spec:
-  serviceName: azure-disk-csi-driver-controller
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
Deployment spec doesn't support this property, so we should remove it.