### PR TITLE
Bumps Dockerfile to OCP 4.8 and go 1.16

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/azure-disk-csi-driver-operator
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.7:base
+FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/github.com/openshift/azure-disk-csi-driver-operator/azure-disk-csi-driver-operator /usr/bin/
 COPY manifests /manifests
 ENTRYPOINT ["/usr/bin/azure-disk-csi-driver-operator"]


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Bumps the Dockerfile to use go 1.16 and OCP 4.8.