### PR TITLE
Include CSIDriver creation in Operator

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: disk.csi.azure.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -2,6 +2,7 @@
 // sources:
 // assets/controller.yaml
 // assets/controller_sa.yaml
+// assets/csidriver.yaml
 // assets/node.yaml
 // assets/node_sa.yaml
 // assets/rbac/attacher_binding.yaml
@@ -254,6 +255,30 @@ func controller_saYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "controller_sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriverYaml = []byte(`apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: disk.csi.azure.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+`)
+
+func csidriverYamlBytes() ([]byte, error) {
+	return _csidriverYaml, nil
+}
+
+func csidriverYaml() (*asset, error) {
+	bytes, err := csidriverYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriver.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -900,6 +925,7 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"controller.yaml":                         controllerYaml,
 	"controller_sa.yaml":                      controller_saYaml,
+	"csidriver.yaml":                          csidriverYaml,
 	"node.yaml":                               nodeYaml,
 	"node_sa.yaml":                            node_saYaml,
 	"rbac/attacher_binding.yaml":              rbacAttacher_bindingYaml,
@@ -959,6 +985,7 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"controller.yaml":    {controllerYaml, map[string]*bintree{}},
 	"controller_sa.yaml": {controller_saYaml, map[string]*bintree{}},
+	"csidriver.yaml":     {csidriverYaml, map[string]*bintree{}},
 	"node.yaml":          {nodeYaml, map[string]*bintree{}},
 	"node_sa.yaml":       {node_saYaml, map[string]*bintree{}},
 	"rbac": {nil, map[string]*bintree{

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -60,6 +60,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"storageclass.yaml",
 			"controller_sa.yaml",
 			"node_sa.yaml",
+			"csidriver.yaml",
 			"rbac/attacher_role.yaml",
 			"rbac/attacher_binding.yaml",
 			"rbac/privileged_role.yaml",


### PR DESCRIPTION
Allows the operator to create the Azure Disk CSIDriver on the server.