### PR TITLE
Add "managed" annotation to CSIDriver

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -2,6 +2,9 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: disk.csi.azure.com
+  annotations:
+    # Used to determine if a CSI driver was created by OCP or by 3rd party operator / helm / yaml files.
+    csi.openshift.io/managed: "true"
 spec:
   attachRequired: true
   podInfoOnMount: true

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -263,6 +263,9 @@ var _csidriverYaml = []byte(`apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: disk.csi.azure.com
+  annotations:
+    # Used to determine if a CSI driver was created by OCP or by 3rd party operator / helm / yaml files.
+    csi.openshift.io/managed: "true"
 spec:
   attachRequired: true
   podInfoOnMount: true


### PR DESCRIPTION
The `csi.openshift.io/managed` annotation will be used to distinguish if a CSI driver is installed + managed by OCP (= the annotation is present) or by some 3rd party script / helm chart / operator.

Eventually, CSO should not start CSI driver operator when it sees CSIDriver without this annotation - it's a signal that the driver was installed by someone else.

@openshift/storage 