### PR TITLE
Bug 1947756: Add maxUnavailable to DaemonSet

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       app: azure-disk-csi-driver-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -297,6 +297,10 @@ spec:
   selector:
     matchLabels:
       app: azure-disk-csi-driver-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Add maxUnavailable to DaemonSet to speed up cluster upgrade by allowing more nodes to be updated simultaneously.