### PR TITLE
Bug 1948603: Fix some failing tests

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -85,7 +85,6 @@ spec:
             - --csi-address=$(ADDRESS)
             - --default-fstype=ext4
             - --feature-gates=Topology=true
-            - --extra-create-metadata=true
             - --http-endpoint=localhost:8202
             - --timeout=15s
             - --v=${LOG_LEVEL}

--- a/assets/rbac/resizer_role.yaml
+++ b/assets/rbac/resizer_role.yaml
@@ -18,3 +18,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -992,6 +992,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
 `)
 
 func rbacResizer_roleYamlBytes() ([]byte, error) {

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -163,7 +163,6 @@ spec:
             - --csi-address=$(ADDRESS)
             - --default-fstype=ext4
             - --feature-gates=Topology=true
-            - --extra-create-metadata=true
             - --http-endpoint=localhost:8202
             - --timeout=15s
             - --v=${LOG_LEVEL}


### PR DESCRIPTION
This patch is the first iteration to fix the CSI certification failing tests.
 
- Fix resizer RBAC.
- Remove --extra-create-metadata=true from provisioner.

CC @openshift/storage
