### PR TITLE
Bug 1948603: Disable volume expansion e2e tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -21,8 +21,10 @@ DriverInfo:
     block: true
     exec: true
     volumeLimits: false
-    controllerExpansion: true
-    nodeExpansion: true
+    # TODO: enable volume resizing once the following issue is fixed:
+    # https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/800
+    controllerExpansion: false
+    nodeExpansion: false
     snapshotDataSource: true
     topology: true
     multipods: true


### PR DESCRIPTION
Currently expansion e2e tests are failing due to an upstream issue:

https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/800

We'll re-enabled them once the issue is fixed.

CC @openshift/storage
