### PR TITLE
Bug 1948603: Disable snapshot tests for now

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -25,6 +25,8 @@ DriverInfo:
     # https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/800
     controllerExpansion: false
     nodeExpansion: false
-    snapshotDataSource: true
+    # TODO: enable snapshot tests once the following issue is fixed:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1913974
+    snapshotDataSource: false
     topology: true
     multipods: true


### PR DESCRIPTION
There's a known issue [1] that needs to be fixed first.  Once that's fixed we should enable snapshot tests again.

CC @openshift/storage

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1913974
