### PR TITLE
Bug 1948603: Re-enable expansion e2e tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -21,10 +21,9 @@ DriverInfo:
     block: true
     exec: true
     volumeLimits: false
-    # TODO: enable volume resizing once the following issue is fixed:
-    # https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/800
-    controllerExpansion: false
-    nodeExpansion: false
+    controllerExpansion: true
+    nodeExpansion: true
+    onlineExpansion: false
     snapshotDataSource: true
     topology: true
     multipods: true


### PR DESCRIPTION
This PR enables the volume expansion tests and disables online expansion, which is currently unsupported in Azure Disk.

CC @openshift/storage 