### PR TITLE
Add volume cloning tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -26,5 +26,6 @@ DriverInfo:
     controllerExpansion: false
     nodeExpansion: false
     snapshotDataSource: true
+    pvcDataSource: true
     topology: true
     multipods: true


### PR DESCRIPTION
Azure Disk claims it supports volume cloning, at least in upstream README. Enable the cloning tests.

cc @duanwei33 - this adds cloning tests to 4.9, but at least we'll see if it's supported and how.