### PR TITLE
Bug 1992148: mount azurestackcloud.json to /etc/azure

### DIFF
--- a/pkg/azurestackhub/azure_stack_hub.go
+++ b/pkg/azurestackhub/azure_stack_hub.go
@@ -24,7 +24,7 @@ const (
 	sslHostPath           = "/etc/ssl/certs"
 	azureCfgName          = "azure-cfg"
 	configEnvName         = "AZURE_ENVIRONMENT_FILEPATH"
-	azureStackCloudConfig = "/etc/kubernetes/azurestackcloud.json"
+	azureStackCloudConfig = "/etc/azure/azurestackcloud.json"
 )
 
 func WithAzureStackHubDaemonSetHook(runningOnAzureStackHub bool) csidrivernodeservicecontroller.DaemonSetHookFunc {


### PR DESCRIPTION
Now we try to mount ASH cloud config to /etc/kubernetes, but it's a read-only file system. So, the mounting fails:

```txt
msg="container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: mounting \"/var/lib/kubelet/pods/9b6be4b7-86c2-45e1-a6ce-032faf62a332/volume-subpaths/azure-cfg/csi-driver/3\" to rootfs at \"/etc/kubernetes/azurestackcloud.json\" caused: open /var/lib/containers/storage/overlay/ed6766de84eff62c52dc3446d5e4b77e2ca9ff2232c6357bff773ff3cd0e0a22/merged/etc/kubernetes/azurestackcloud.json: read-only file system"
```

To prevent this, this commit changes the mounting point to /etc/azure