### PR TITLE
Bug 1992875: Use own cloud credentials

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -39,6 +39,32 @@ spec:
                   matchLabels:
                     app: azure-disk-csi-driver-controller
                 topologyKey: kubernetes.io/hostname
+      initContainers:
+        # Merge /etc/kubernetes/cloud.conf (on the host) with secret "azure-disk-credentials" into "merged-cloud-config" emptydir.
+        - name: azure-inject-credentials
+          image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
+          command:
+            - /azure-config-credentials-injector
+          args:
+            - --cloud-config-file-path=/etc/cloud-config/cloud.conf
+            - --output-file-path=/etc/merged-cloud-config/cloud.conf
+          env:
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-disk-credentials
+                  key: azure_client_id
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: azure-disk-credentials
+                  key: azure_client_secret
+          volumeMounts:
+            - name: host-cloud-config
+              mountPath: /etc/cloud-config
+              readOnly: true
+            - name: merged-cloud-config
+              mountPath: /etc/merged-cloud-config
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}
@@ -69,7 +95,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-            - name: cloud-sa-volume
+            - name: merged-cloud-config
               mountPath: /etc/kubernetes/
               readOnly: true
             - name: msi
@@ -279,7 +305,7 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
-        - name: cloud-sa-volume
+        - name: host-cloud-config
           hostPath:
             path: /etc/kubernetes/
         - name: msi
@@ -288,3 +314,5 @@ spec:
         - name: metrics-serving-cert
           secret:
             secretName: azure-disk-csi-driver-controller-metrics-serving-cert
+        - name: merged-cloud-config
+          emptydir:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -25,6 +25,32 @@ spec:
         - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
+      initContainers:
+        # Merge /etc/kubernetes/cloud.conf (on the host) with secret "azure-disk-credentials" into "merged-cloud-config" emptydir.
+        - name: azure-inject-credentials
+          image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
+          command:
+            - /azure-config-credentials-injector
+          args:
+            - --cloud-config-file-path=/etc/cloud-config/cloud.conf
+            - --output-file-path=/etc/merged-cloud-config/cloud.conf
+          env:
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-disk-credentials
+                  key: azure_client_id
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: azure-disk-credentials
+                  key: azure_client_secret
+          volumeMounts:
+            - name: host-cloud-config
+              mountPath: /etc/cloud-config
+              readOnly: true
+            - name: merged-cloud-config
+              mountPath: /etc/merged-cloud-config
       containers:
         - name: csi-driver
           securityContext:
@@ -55,7 +81,7 @@ spec:
               name: mountpoint-dir
             - mountPath: /etc/kubernetes/
               readOnly: true
-              name: cloud-sa-volume
+              name: merged-cloud-config
             - mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
               name: msi
@@ -139,7 +165,7 @@ spec:
         - hostPath:
             path: /etc/kubernetes/
             type: Directory
-          name: cloud-sa-volume
+          name: host-cloud-config
         - hostPath:
             path: /var/lib/waagent/ManagedIdentity-Settings
           name: msi
@@ -155,3 +181,5 @@ spec:
             path: /sys/class/scsi_host/
             type: Directory
           name: scsi-host-dir
+        - name: merged-cloud-config
+          emptydir:

--- a/pkg/azurestackhub/azure_stack_hub_test.go
+++ b/pkg/azurestackhub/azure_stack_hub_test.go
@@ -2,6 +2,8 @@ package azurestackhub
 
 import (
 	"context"
+	"testing"
+
 	cfgV1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/azure-disk-csi-driver-operator/assets"
 	"github.com/openshift/client-go/config/clientset/versioned/fake"
@@ -10,7 +12,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"testing"
 )
 
 func TestAzureStackHubDetectionHappyPath(t *testing.T) {
@@ -40,7 +41,7 @@ func TestInjectPodSpecHappyPath(t *testing.T) {
 	assert.Nil(t, yaml.Unmarshal(file, dep))
 
 	injectEnvAndMounts(&dep.Spec.Template.Spec)
-	assert.Len(t, dep.Spec.Template.Spec.Volumes, 5)
+	assert.Len(t, dep.Spec.Template.Spec.Volumes, 6)
 	foundCfgVolume := false
 	for _, v := range dep.Spec.Template.Spec.Volumes {
 		if v.Name == azureCfgName {


### PR DESCRIPTION
Use credentials provided by cloud-credential-operator (CCO, https://github.com/openshift/cluster-storage-operator/pull/206), i.e. Secret `azure-disk-credentials`. To use this secret, the operator adds an init container to driver pods to merge cloud.conf from the host (without the credentials) with the provided secret.  The init container uses cluster-cloud-controller-manager-operator's `azure-config-credentials-injector` that does the merge.

Therefore:

* Replace `${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}` with the right image name.
* Add `azure-config-credentials-injector` to the CSI driver pod as an init container.
* Make sure to restart all pods when the secret provided by CCO changes. This part should move to library-go eventually.