### PR TITLE
Bug 2058626: Fix CSIDriver fsGroupPolicy

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -8,3 +8,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
+  fsGroupPolicy: File


### PR DESCRIPTION
Always apply fsGroup and don't depend on heuristics.

It's important when in-tree volume plugin provisions PVs with `fsType: ""` by default.

This fixes installation of OCP cluster with PVCs for Prometheus.