### PR TITLE
Fix CSIDriver fsGroupPolicy

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -7,4 +7,9 @@ metadata:
     csi.openshift.io/managed: "true"
 spec:
   attachRequired: true
+  fsGroupPolicy: File
   podInfoOnMount: true
+  requiresRepublish: false
+  storageCapacity: false
+  volumeLifecycleModes:
+    - Persistent

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6
+	github.com/openshift/library-go v0.0.0-20220308130806-fb1b36724e8b
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6b
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
 github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6 h1:HS6brMoum1oJyFriix+Ae3J2FfvK9u9TBqUu+JnG/pc=
 github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
+github.com/openshift/library-go v0.0.0-20220308130806-fb1b36724e8b h1:OtFKWe9ZnsdV0k7+63qjr9FETwAIyOTxiYX2fOxxiJk=
+github.com/openshift/library-go v0.0.0-20220308130806-fb1b36724e8b/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -206,13 +206,13 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *admissionregistrationv1.MutatingWebhookConfiguration:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -2,14 +2,13 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
-	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -58,39 +57,18 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 	return actual, true, err
 }
 
-// ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
-func ApplyCSIDriverV1Beta1(ctx context.Context, client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
-	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		requiredCopy := required.DeepCopy()
-		actual, err := client.CSIDrivers().Create(
-			ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*storagev1beta1.CSIDriver), metav1.CreateOptions{})
-		reportCreateEvent(recorder, required, err)
-		return actual, true, err
+// ApplyCSIDriver merges objectmeta, does not worry about anything else
+func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, requiredOriginal *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+
+	required := requiredOriginal.DeepCopy()
+	if required.Annotations == nil {
+		required.Annotations = map[string]string{}
 	}
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
 	if err != nil {
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
-	existingCopy := existing.DeepCopy()
-
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
-	}
-
-	if klog.V(4).Enabled() {
-		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
-	}
-
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
-	return actual, true, err
-}
-
-// ApplyCSIDriver merges objectmeta, does not worry about anything else
-func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
 	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
@@ -103,21 +81,46 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	metadataModified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
+	resourcemerge.EnsureObjectMeta(metadataModified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
+	requiredSpecHash := required.Annotations[specHashAnnotation]
+	existingSpecHash := existing.Annotations[specHashAnnotation]
+	sameSpec := requiredSpecHash == existingSpecHash
+	if sameSpec && !*metadataModified {
+		return existing, false, nil
 	}
 
 	if klog.V(4).Enabled() {
 		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	// TODO: Spec is read-only, so this will fail if user changes it. Should we simply ignore it?
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
+	if sameSpec {
+		// Update metadata by a simple Update call
+		actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, required, err)
+		return actual, true, err
+	}
+
+	existingCopy.Spec = required.Spec
+	existingCopy.ObjectMeta.ResourceVersion = ""
+	// Spec is read-only after creation. Delete and re-create the object
+	err = client.CSIDrivers().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+	reportDeleteEvent(recorder, existingCopy, err, "Deleting CSIDriver to re-create it with updated parameters")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return existing, false, err
+	}
+	actual, err := client.CSIDrivers().Create(ctx, existingCopy, metav1.CreateOptions{})
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		// Delete() few lines above did not really delete the object,
+		// the API server is probably waiting for a finalizer removal or so.
+		// Report an error, but something else than "Already exists", because
+		// that would be very confusing - Apply failed because the object
+		// already exists???
+		err = fmt.Errorf("failed to re-create CSIDriver object %s, waiting for the original object to be deleted", existingCopy.Name)
+	}
+	reportCreateEvent(recorder, existingCopy, err)
 	return actual, true, err
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -61,7 +61,7 @@ type StaticResourceController struct {
 	name                   string
 	manifests              []conditionalManifests
 	ignoreNotFoundOnCreate bool
-	preconfitions          []StaticResourcesPreconditionsFuncType
+	preconditions          []StaticResourcesPreconditionsFuncType
 
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
@@ -106,7 +106,7 @@ func NewStaticResourceController(
 		operatorClient: operatorClient,
 		clients:        clients,
 
-		preconfitions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
+		preconditions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
 
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
 
@@ -136,7 +136,7 @@ func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceC
 //
 // When the requirement is not met, the controller reports degraded status.
 func (c *StaticResourceController) WithPrecondition(precondition StaticResourcesPreconditionsFuncType) *StaticResourceController {
-	c.preconfitions = append(c.preconfitions, precondition)
+	c.preconditions = append(c.preconditions, precondition)
 	return c
 }
 
@@ -283,7 +283,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 		return nil
 	}
 
-	for _, precondition := range c.preconfitions {
+	for _, precondition := range c.preconditions {
 		ready, err := precondition(ctx)
 		// We don't care about the other preconditions, we just stop on the first one.
 		if !ready {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6
+# github.com/openshift/library-go v0.0.0-20220308130806-fb1b36724e8b
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
Always apply fsGroup and don't depend on heuristics.

It's important when in-tree volume plugin provisions PVs with `fsType: ""` by default - when CSI migration is enabled, CSI volume plugin gets a volume with `fsType: ""` and it must decide the volume still needs fsGroup applied.

Bump library-go to get ApplyCSIDriver fixes to re-create CSIDriver when a change in needed.

@openshift/storage 