### PR TITLE
Bug 2073373: Sync cmdline arguments with upstream

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -137,6 +137,8 @@ spec:
             - --feature-gates=Topology=true
             - --http-endpoint=localhost:8202
             - --timeout=15s
+            - --extra-create-metadata=true
+            - --strict-topology=true
             - --leader-election
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
@@ -180,7 +182,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --http-endpoint=localhost:8203
-            - --timeout=120s
+            - --timeout=600s
             - --leader-election
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
@@ -222,6 +224,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --http-endpoint=localhost:8204
+            - --handle-volume-inuse-error=true
             - --leader-election
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}


### PR DESCRIPTION
Sync arguments of all containers with the upstream deployment helm chart, https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/07a62580519e28d1bf9a7bd7adf11615d337cdbc/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml

I'd prefer to use the same parameters as upstream, for easy comparison between CSI driver versions.