### PR TITLE
Bug 2095049: Only use credentials that are provided by the azure-inject-credential…

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -75,6 +75,9 @@ spec:
             - --logtostderr
             - --metrics-address=localhost:8201
             - --v=${LOG_LEVEL}
+            # Use credentials provided by the azure-inject-credentials container
+            - --cloud-config-secret-name=""
+            - --cloud-config-secret-namespace=""
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: "/etc/kubernetes/cloud.conf"

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -64,6 +64,9 @@ spec:
             - --v=${LOG_LEVEL}
             - --nodeid=$(KUBE_NODE_NAME)
             # - --metrics-address=0.0.0.0:29605
+            # Use credentials provided by the azure-inject-credentials container
+            - --cloud-config-secret-name=""
+            - --cloud-config-secret-namespace=""
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: "/etc/kubernetes/cloud.conf"


### PR DESCRIPTION
The CSI driver supports reading Azure credentials either from a given secret or from a configuration file provided via an environment variable. Our injector container creates a valid credentials file that we pass in to the CSI driver via an environment variable.

Credentials provided by secrets have precedence over those provided via the environment variable. The CSI driver defaults to `kube-system/azure-cloud-provider` if no secret is provided via CLI arguments.

This secret doesn't exist in regular OCP clusters, but it does exist in Azure Red Hat OpenShift, but with limited data. This cause some some operations to fail due to lack of sufficient permissions.

In this patch we overwrite the default secret and we make sure to use the credentials provided by the azure-inject-credentials container.

CC @openshift/storage 
