### PR TITLE
OCPBUGS-3659: Don't expose metrics port to whole network

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -63,7 +63,9 @@ spec:
             - --logtostderr
             - --v=${LOG_LEVEL}
             - --nodeid=$(KUBE_NODE_NAME)
-            # - --metrics-address=0.0.0.0:29605
+            # Set localhost port to avoid exposing to whole
+            # network. We don't scrape metrics on node
+            - --metrics-address=localhost:8206
             # Use credentials provided by the azure-inject-credentials container
             - --cloud-config-secret-name=""
             - --cloud-config-secret-namespace=""


### PR DESCRIPTION
Currently the CSI driver doesn't collect any metrics on the Node. However, by the default the CSI driver exposes the `0.0.0.0:29605` port if none is specified. As a result, set a localhost port to avoid exposing the port to the network.

CC @openshift/storage 