### PR TITLE
Bug 2106736: Add multiplePVsSameID capability

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -28,6 +28,7 @@ DriverInfo:
     pvcDataSource: true
     topology: true
     multipods: true
+    multiplePVsSameID: true
 Timeouts:
   PodStart: 15m
   PodDelete: 15m


### PR DESCRIPTION
This CSI driver can handle multiple PVs that have the same VolumeHandle used on the same node.

cc @openshift/storage