### PR TITLE
[release-4.10] OCPBUGS-8020: Adjust client-side QPS, burst and worker threads in provisioner and attacher sidecars

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -229,6 +229,7 @@ spec:
           image: ${RESIZER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --timeout=240s
             - --csi-address=$(ADDRESS)
             - --http-endpoint=localhost:8204
             - --leader-election

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -139,12 +139,15 @@ spec:
             - --default-fstype=ext4
             - --feature-gates=Topology=true
             - --http-endpoint=localhost:8202
-            - --timeout=15s
+            - --timeout=30s
             - --leader-election
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --v=${LOG_LEVEL}
+            - --worker-threads=100
+            - --kube-api-qps=50
+            - --kube-api-burst=100
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -183,12 +186,15 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --http-endpoint=localhost:8203
-            - --timeout=120s
+            - --timeout=600s # Upstream sets this to 1200s, but we consider that too high
             - --leader-election
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --v=${LOG_LEVEL}
+            - --worker-threads=500
+            - --kube-api-qps=50
+            - --kube-api-burst=100
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
This is syncing with the values [from upstream](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/deploy/v1.26.2/csi-azuredisk-controller.yam).

To test this out I created a StatefulSet with 120 replicas and then deleted it (including the volumes). Without this patch I could see that requests were being rate-limited in the client side. Both in the attacher

```
$ oc -n openshift-cluster-csi-drivers logs azure-disk-csi-driver-controller-64884fb954-5bkbk csi-attacher | rg client-side
I0217 18:07:26.394533       1 request.go:533] Waited for 82.41369ms due to client-side throttling, not priority and fairness, request: PATCH:https://172.30.0.1:443/apis/storage.k8s.io/v1/volumeattachments/csi-0c1519f43602836c2c51d6ef37d3ff786d08862b5f6026fc0c17aa738d66d912
(...)
```

and in the provisioner

```
$ oc -n openshift-cluster-csi-drivers logs azure-disk-csi-driver-controller-64884fb954-5bkbk csi-provisioner | grep 'client-side throttling'
I0217 18:07:21.572427       1 request.go:614] Waited for 192.707516ms due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/default/events
(...)
```

I repeated this experiment with this patch and no messages like this were reported in the logs.

Memory usage metrics (with interleaving configurations, note the restarts):

![metrics-provisioner](https://user-images.githubusercontent.com/1286651/219765478-1bbf3568-c7c5-4eb9-9e9a-5e9e9c5e0f81.png)

![metrics-attacher](https://user-images.githubusercontent.com/1286651/219765483-b102406e-80d6-4808-a368-fd21f2e274f1.png)

CC @openshift/storage 
