### PR TITLE
CCO-324: Mount serviceaccount token into csi-driver container

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -109,6 +109,9 @@ spec:
             - name: msi
               mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
           resources:
             requests:
               memory: 50Mi
@@ -352,3 +355,9 @@ spec:
             secretName: azure-disk-csi-driver-controller-metrics-serving-cert
         - name: merged-cloud-config
           emptydir:
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift

--- a/pkg/azurestackhub/azure_stack_hub_test.go
+++ b/pkg/azurestackhub/azure_stack_hub_test.go
@@ -41,7 +41,7 @@ func TestInjectPodSpecHappyPath(t *testing.T) {
 	assert.Nil(t, yaml.Unmarshal(file, dep))
 
 	injectEnvAndMounts(&dep.Spec.Template.Spec)
-	assert.Len(t, dep.Spec.Template.Spec.Volumes, 6)
+	assert.Len(t, dep.Spec.Template.Spec.Volumes, 7)
 	foundCfgVolume := false
 	for _, v := range dep.Spec.Template.Spec.Volumes {
 		if v.Name == azureCfgName {
@@ -59,7 +59,7 @@ func TestInjectPodSpecHappyPath(t *testing.T) {
 		}
 	}
 	assert.NotNil(t, csiDriver, "no csi-driver container found")
-	assert.Len(t, csiDriver.VolumeMounts, 4)
+	assert.Len(t, csiDriver.VolumeMounts, 5)
 	foundCfgVolumeMount := false
 	for _, v := range csiDriver.VolumeMounts {
 		if v.Name == azureCfgName {


### PR DESCRIPTION
Mount the service account token into the csi-driver container to enable Azure workload identity tokens.