### PR TITLE
STOR-1696: Fix gofmt

### DIFF
--- a/pkg/azurestackhub/azure_stack_hub.go
+++ b/pkg/azurestackhub/azure_stack_hub.go
@@ -47,7 +47,7 @@ func WithAzureStackHubDeploymentHook(runningOnAzureStackHub bool) deploymentcont
 
 func injectEnvAndMounts(spec *coreV1.PodSpec) {
 	containers := spec.Containers
-	for i, _ := range containers {
+	for i := range containers {
 		c := &spec.Containers[i]
 		if c.Name == "csi-driver" {
 			c.Env = append(c.Env, coreV1.EnvVar{

--- a/pkg/dependencymagnet/dependencymagnet.go
+++ b/pkg/dependencymagnet/dependencymagnet.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package dependencymagnet


### PR DESCRIPTION
Run `make update-gofmt` with go 1.21 to prepare the repo to merge to csi-operator that insists on clean `make verify-gofmt`.

@openshift/storage 