### PR TITLE
STOR-1713: Mark the repository obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!warning]
+> **This repo is obsolete in OCP 4.16.**
+> Azure Disk CSI driver operator in 4.16 and newer is built from https://github.com/openshift/csi-operator.
+> 4.15 and older branches in this repo are still in use, until EOL of the corresponding OCP version.
+> See [this enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-operator-merge.md) for details.
+
 # azure-disk-csi-driver-operator
 
 An operator to deploy the [Azure Disk CSI Driver](https://github.com/openshift/azure-disk-csi-driver) in OKD.


### PR DESCRIPTION
Add a warning to README that the repo is not used in 4.16.

@openshift/storage 